### PR TITLE
Add handling for sensitivity runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,7 +155,9 @@ preprocessing/final/*
 !preprocessing/final/README.md
 inputs/final/*
 !inputs/final/README.md
+
 examples/Results/*
 !examples/Results/README.md
+!examples/Results/sens/combine_sens.py
 examples/diagnostic/*
 examples/Results/temperature_all.csv

--- a/.gitignore
+++ b/.gitignore
@@ -156,8 +156,10 @@ preprocessing/final/*
 inputs/final/*
 !inputs/final/README.md
 
-examples/Results/*
+examples/Results/**
 !examples/Results/README.md
+!examples/Results/sens/
 !examples/Results/sens/combine_sens.py
+
 examples/diagnostic/*
 examples/Results/temperature_all.csv

--- a/create_custom_scenarios.py
+++ b/create_custom_scenarios.py
@@ -1,5 +1,6 @@
 """Convert ICCT SLCP emissions to FaIR format and combine with CMIP6 emissions data."""
 
+import os
 import time
 import pandas as pd
 
@@ -10,8 +11,14 @@ pd.set_option('display.max_columns', 100000)
 # User inputs
 BASE_YR = 1940
 END_YR = 2050
-EMS_IN = 'preprocessing/final/PACE_inventory_long.csv'
+# EMS_IN = 'preprocessing/final/PACE_inventory_long.csv'
 # EMS_IN = 'preprocessing/final/PACE_inventory_levers_long.csv'
+EMS_IN = 'preprocessing/final/PACE_inventory_long_sens.csv' # Triggers special handling for sensitivity runs
+BATCH_SIZE = 10
+
+if EMS_IN == 'preprocessing/final/PACE_inventory_long_sens.csv':
+    RUNNING_SENS = True
+
 BASELINE_SCEN = 'BAU'
 NOX_VAR = 'NOx aviation'
 SSPs = ['ssp119']  # Currently hardcoded to only handle ssp119
@@ -129,6 +136,38 @@ def clean_inputs(ems, conc, forc, species_to_rcmip):
     return ems, conc, forc
 
 
+def handle_sensitivity_input(ems_orig, conc_orig, forc_orig, slcp_ems, species_to_rcmip, scenarios):
+    """
+    If a sensitivity run is being executed, create separate input files for batches of sensitivity runs.
+    """
+    id_cols = ['Year', 'Species', 'Units', 'Source', 'Sector']
+
+    # Ensure 'Results/sens/{BATCH_SIZE}' exists
+    if not os.path.exists(f'inputs/final/batches/{BATCH_SIZE}'):
+        os.makedirs(f'inputs/final/batches/{BATCH_SIZE}')
+    num_scenarios = len(scenarios)
+    num_batches = round(num_scenarios/BATCH_SIZE)
+    # Run in batches
+    for i in range(0, num_scenarios, BATCH_SIZE):
+        st = time.time()
+
+        scenario_batch = list(scenarios[i:i + BATCH_SIZE])
+
+        # Filter to batch
+        slcp_ems_batch = slcp_ems[id_cols + scenario_batch].copy()
+
+        # Align inputs with FaIR
+        ems, conc, forc = align_inputs_with_fair(ems_orig.copy(), conc_orig.copy(), forc_orig.copy(), slcp_ems_batch,
+                                                 species_to_rcmip, scenario_batch)
+
+        # Store each batched input in a separate directory
+        forc.to_csv(f'inputs/final/batches/{BATCH_SIZE}/rcmip-radiative-forcing-annual-means-v5-1-0_{round(i/BATCH_SIZE)}.csv', index=False)
+        ems.to_csv(f'inputs/final/batches/{BATCH_SIZE}/rcmip-emissions-annual-means-v5-1-0_{round(i/BATCH_SIZE)}.csv', index=False)
+        conc.to_csv(f'inputs/final/batches/{BATCH_SIZE}/rcmip-concentrations-annual-means-v5-1-0_{round(i/BATCH_SIZE)}.csv', index=False)
+
+        print(f'Ran batch {i/BATCH_SIZE} of {num_batches} ({i/BATCH_SIZE/num_batches*100:.2f}%) in {time.time() - st:.2f} seconds')
+
+
 def align_inputs_with_fair(ems, conc, forc, slcp_ems, species_to_rcmip, scenarios):
     """
     Align the inputs with FaIR by creating new scenarios and adjusting the emissions.
@@ -153,35 +192,31 @@ def adjust_forc(slcp_ems, forc, scenarios):
     and stratospheric NOx.
     """
     ct_var = 'Effective Radiative Forcing|Anthropogenic|Other|Contrails and Contrail-induced Cirrus'
-    nox_var_fair = 'Effective Radiative Forcing|Anthropogenic|Other|CH4 Oxidation Stratospheric H2O'
     h2o_var = 'Effective Radiative Forcing|Anthropogenic|Other|CH4 Oxidation Stratospheric H2O'
     SSP = 'ssp119'
 
-    # Use ICCT estimates for contrail BAU and striving under SSP119
+    # Use ICCT estimates for contrail BAU and striving under SSP119. Set as contrail total forcing since
+    # contrails come from no other source
     # Contrails ---------------------------------------------------------------------------------------------------
     for yr in range(BASE_YR, END_YR+1):
-        bau = slcp_ems[(slcp_ems['Year'] == yr) & (slcp_ems['Species'] == 'contrails')][BASELINE_SCEN].values[0]
-
-        # For contrails, we add an additional step to set the BAU to 0 for all scenarios since contrails only come
-        # from aviation.
-        for scen in forc['Scenario'].unique():
-            # Set default to BAU
-            forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == scen), str(yr)] = bau
-
-        # Adjust the BAU for contrail scenarios
-        for striving_scen in [s for s in scenarios if s!=BASELINE_SCEN]:
+        # Adjust the BAU for intervention scenarios
+        for scen in scenarios:
             # Set the striving scenario
-            striving = slcp_ems[(slcp_ems['Year'] == yr) & (slcp_ems['Species'] == 'contrails')][striving_scen].values[0]
+            ct_val = slcp_ems[(slcp_ems['Year'] == yr) & (slcp_ems['Species'] == 'contrails')][scen].values[0]
 
-            forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_{striving_scen}'), str(yr)] = striving
-            forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_contrails_Aviation_{striving_scen}'), str(
-                yr)] = striving
+            forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_{scen}'), str(yr)] = ct_val
+            if scen != BASELINE_SCEN:
+                forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_contrails_Aviation_{scen}'), str(
+                    yr)] = ct_val
 
+        # Set to 0 in zero-out scenarios, because contrails come from no other source
         forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_zero_tra'), str(yr)] = 0
-
-        # Add zero contrails scenario
         forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_contrails_Aviation_zero'), str(
             yr)] = 0
+
+    # We only consider contrails for sensitivity runs to save on compute
+    if RUNNING_SENS:
+        return forc
 
     # Stratospheric H2O ----------------------------------------------------------------------------------------------
     for yr in range(BASE_YR, END_YR+1):
@@ -240,21 +275,25 @@ def create_new_scenarios(ems, conc, forc, scenarios, slcp_ems):
     forc = pd.concat([forc, forc[forc['Scenario'] == SSP].replace(SSP, f'{SSP}_zero_tra')])
     conc = pd.concat([conc, conc[conc['Scenario'] == SSP].replace(SSP, f'{SSP}_zero_tra')])
 
-    for specie in slcp_ems['Species'].unique():
-        for sector in slcp_ems['Sector'].unique():
-            # for source in slcp_ems['Source'].unique():
-            if slcp_ems[(slcp_ems['Species'] == specie) & (slcp_ems['Sector'] == sector)].empty:
-                continue
+    # If running a contrail sensitivity run, skip species-specific scenarios (only contrails are modified)
+    if not RUNNING_SENS:
+        species_list = slcp_ems['Species'].unique()
 
-            for scenario in scenarios:
-                ems = pd.concat([ems, ems[(ems['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_{scenario}')])
-                conc = pd.concat([conc, conc[(conc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_{scenario}')])
-                forc = pd.concat([forc, forc[(forc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_{scenario}')])
+        for specie in species_list:
+            for sector in slcp_ems['Sector'].unique():
+                # for source in slcp_ems['Source'].unique():
+                if slcp_ems[(slcp_ems['Species'] == specie) & (slcp_ems['Sector'] == sector)].empty:
+                    continue
 
-            # Add zero scenarios
-            ems = pd.concat([ems, ems[(ems['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_zero')])
-            conc = pd.concat([conc, conc[(conc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_zero')])
-            forc = pd.concat([forc, forc[(forc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_zero')])
+                for scenario in scenarios:
+                    ems = pd.concat([ems, ems[(ems['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_{scenario}')])
+                    conc = pd.concat([conc, conc[(conc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_{scenario}')])
+                    forc = pd.concat([forc, forc[(forc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_{scenario}')])
+
+                # Add zero scenarios
+                ems = pd.concat([ems, ems[(ems['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_zero')])
+                conc = pd.concat([conc, conc[(conc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_zero')])
+                forc = pd.concat([forc, forc[(forc['Scenario'] == SSP)].replace(SSP, f'{SSP}_{specie}_{sector}_zero')])
 
     return ems, conc, forc
 
@@ -354,19 +393,23 @@ def main():
     slcp_ems, scenarios = clean_slcp_ems(slcp_ems)
     ems, conc, forc = clean_inputs(ems, conc, forc, species_to_rcmip)
 
-    # Align inputs with FaIR
-    ems, conc, forc = align_inputs_with_fair(ems, conc, forc, slcp_ems, species_to_rcmip, scenarios)
+    if RUNNING_SENS:
+        # Fully handles adjustments and export for sensitivity runs
+        handle_sensitivity_input(ems, conc, forc, slcp_ems, species_to_rcmip, scenarios)
+    else:
+        # Align inputs with FaIR
+        ems, conc, forc = align_inputs_with_fair(ems, conc, forc, slcp_ems, species_to_rcmip, scenarios)
 
-    # Export FaIR-ready final inputs
-    ems.to_csv(EMISSIONS_OUT, index=False)
-    conc.to_csv(CONCENTRATION_OUT, index=False)
-    forc.to_csv(FORCING_OUT, index=False)
+        # Export FaIR-ready final inputs
+        ems.to_csv(EMISSIONS_OUT, index=False)
+        conc.to_csv(CONCENTRATION_OUT, index=False)
+        forc.to_csv(FORCING_OUT, index=False)
 
-    # Create a long version along year for validation
-    ems_long = ems.melt(id_vars=['Model', 'Scenario', 'Region', 'Variable', 'Unit', 'Mip_Era', 'Activity_Id'], var_name='Year', value_name='ems')
-    ems_long.to_csv(EMISSIONS_OUT_LONG, index=False)
-    forc_long = forc.melt(id_vars=['Model', 'Scenario', 'Region', 'Variable', 'Unit', 'Mip_Era', 'Activity_Id'], var_name='Year', value_name='ems')
-    forc_long.to_csv(FORCING_OUT_LONG, index=False)
+        # Create a long version along year for validation
+        ems_long = ems.melt(id_vars=['Model', 'Scenario', 'Region', 'Variable', 'Unit', 'Mip_Era', 'Activity_Id'], var_name='Year', value_name='ems')
+        ems_long.to_csv(EMISSIONS_OUT_LONG, index=False)
+        forc_long = forc.melt(id_vars=['Model', 'Scenario', 'Region', 'Variable', 'Unit', 'Mip_Era', 'Activity_Id'], var_name='Year', value_name='ems')
+        forc_long.to_csv(FORCING_OUT_LONG, index=False)
 
     print(f"Script executed in {time.time() - st:.2f} seconds.")
 

--- a/create_custom_scenarios.py
+++ b/create_custom_scenarios.py
@@ -11,11 +11,12 @@ pd.set_option('display.max_columns', 100000)
 # User inputs
 BASE_YR = 1940
 END_YR = 2050
-# EMS_IN = 'preprocessing/final/PACE_inventory_long.csv'
+EMS_IN = 'preprocessing/final/PACE_inventory_long.csv'
 # EMS_IN = 'preprocessing/final/PACE_inventory_levers_long.csv'
-EMS_IN = 'preprocessing/final/PACE_inventory_long_sens.csv' # Triggers special handling for sensitivity runs
+# EMS_IN = 'preprocessing/final/PACE_inventory_long_sens.csv' # Triggers special handling for sensitivity runs
 BATCH_SIZE = 100
 
+RUNNING_SENS = False
 if EMS_IN == 'preprocessing/final/PACE_inventory_long_sens.csv':
     RUNNING_SENS = True
 
@@ -205,9 +206,8 @@ def adjust_forc(slcp_ems, forc, scenarios):
             ct_val = slcp_ems[(slcp_ems['Year'] == yr) & (slcp_ems['Species'] == 'contrails')][scen].values[0]
 
             forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_{scen}'), str(yr)] = ct_val
-            if scen != BASELINE_SCEN:
-                forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_contrails_Aviation_{scen}'), str(
-                    yr)] = ct_val
+            forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_contrails_Aviation_{scen}'), str(
+                yr)] = ct_val
 
         # Set to 0 in zero-out scenarios, because contrails come from no other source
         forc.loc[(forc['Variable'] == ct_var) & (forc['Scenario'] == f'{SSP}_zero_tra'), str(yr)] = 0

--- a/create_custom_scenarios.py
+++ b/create_custom_scenarios.py
@@ -14,7 +14,7 @@ END_YR = 2050
 # EMS_IN = 'preprocessing/final/PACE_inventory_long.csv'
 # EMS_IN = 'preprocessing/final/PACE_inventory_levers_long.csv'
 EMS_IN = 'preprocessing/final/PACE_inventory_long_sens.csv' # Triggers special handling for sensitivity runs
-BATCH_SIZE = 10
+BATCH_SIZE = 100
 
 if EMS_IN == 'preprocessing/final/PACE_inventory_long_sens.csv':
     RUNNING_SENS = True

--- a/examples/Results/sens/combine_sens.py
+++ b/examples/Results/sens/combine_sens.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import os
+import matplotlib.pyplot as plt
+
+# Set pandas display options so that we can see all columns when debugging
+pd.set_option('display.width', None)
+pd.set_option('display.max_columns', None)
+
+
+def collect_data(batch_size):
+
+    # Read all input data
+    all = []
+    for filename in os.listdir(f'{batch_size}'):
+        print(filename)
+        if filename.endswith('.csv'):
+            filepath = os.path.join(f'{batch_size}', filename)
+            df = pd.read_csv(filepath)
+            all.append(df)
+
+    all = pd.concat(all, ignore_index=True)
+
+    # Drop 'Lower limit', 'Upper limit', and 'Mean' Scenarios
+    all = all[~all['scenario'].isin(['Lower limit', 'Upper limit', 'Mean', 'ssp119', 'ssp119_BAU'])]
+
+    ssp119_zero_tra = all[all['scenario'] == 'ssp119_zero_tra'].copy().drop_duplicates() # there will be a zero scenario for each run
+    # Ensure no duplicate years in ssp119_zero_tra
+    assert len(ssp119_zero_tra['timebounds'].unique()) == len(ssp119_zero_tra), "Duplicate years in ssp119_zero_tra"
+    all = all[all['scenario'] != 'ssp119_zero_tra'].copy()
+    all = all.merge(ssp119_zero_tra[['timebounds', 'temp']].rename(columns={'temp': 'temp_zero'}), on='timebounds', how='left')
+    all['Attributable temp'] = all['temp'] - all['temp_zero']
+    all = all.drop(columns=['temp_zero'])
+
+    # Calculate a mean and upper/lower 95th percentile
+    avg = all.groupby(["timebounds"], as_index=False, dropna=False).agg({"Attributable temp": "mean"})
+    avg = avg.rename(columns={'Attributable temp': 'Mean'})
+
+    quantiles = all.groupby('timebounds')['Attributable temp'].quantile([0.025, 0.975]).unstack()
+    quantiles.columns = ['lower_95th', 'upper_95th']
+
+    avg_and_quantiles = avg.merge(quantiles, on='timebounds', how='left')
+    # Convert to long with 'Scenario'
+    avg_and_quantiles_long = avg_and_quantiles.melt(id_vars=['timebounds'], var_name='scenario', value_name='temp')
+
+    # Concatenate
+    # all = pd.concat([avg_and_quantiles_long, all], ignore_index=True)
+
+    # avg_and_quantiles = avg_and_quantiles.drop(columns=['lower_95th', 'upper_95th'])
+
+    # Merge the two dataframes
+    # all = all.merge(avg_and_quantiles, on='timebounds', how='left')
+
+    return all, avg_and_quantiles
+
+
+
+def main():
+    """Read all input data from the 'sens' directory, combine them, and save the results."""
+    batch_size = 10
+
+    all, avg_and_quantiles = collect_data(batch_size)
+
+    all.to_csv(f'all_sensitivity_runs_{batch_size}.csv', index=False)
+    avg_and_quantiles.to_csv(f'avg_sensitivity_runs_{batch_size}.csv', index=False)
+
+
+if __name__ == "__main__":
+        main()

--- a/examples/Results/sens/combine_sens.py
+++ b/examples/Results/sens/combine_sens.py
@@ -42,21 +42,13 @@ def collect_data(batch_size):
     # Convert to long with 'Scenario'
     avg_and_quantiles_long = avg_and_quantiles.melt(id_vars=['timebounds'], var_name='scenario', value_name='temp')
 
-    # Concatenate
-    # all = pd.concat([avg_and_quantiles_long, all], ignore_index=True)
-
-    # avg_and_quantiles = avg_and_quantiles.drop(columns=['lower_95th', 'upper_95th'])
-
-    # Merge the two dataframes
-    # all = all.merge(avg_and_quantiles, on='timebounds', how='left')
-
-    return all, avg_and_quantiles
+    return all, avg_and_quantiles_long
 
 
 
 def main():
     """Read all input data from the 'sens' directory, combine them, and save the results."""
-    batch_size = 10
+    batch_size = 100
 
     all, avg_and_quantiles = collect_data(batch_size)
 

--- a/examples/run_cmip6.py
+++ b/examples/run_cmip6.py
@@ -18,15 +18,15 @@ MIN_YEAR = 1940
 MAX_YEAR = 2050
 BASE_SCEN = 'Historical Trends'
 
-# Define output paths. NOTE: "lever" and "sense", if included in the TEMP_OUT filename, are a special keywords that
+# Define output paths. NOTE: "lever" and "sens", if included in the TEMP_OUT filename, are a special keywords that
 # triggers lever attribution postprocessing (renormalization) or sensitivity run processing. If running a lever-based
 # scenario, ensure that "lever" is in the filename and INTERMEDIATE_OUT is additionally defined
 TEMP_OUT = 'Results/temperature_sens_Sep17_2025.csv' # 'Results/temperature_lever_Sep17_2025.csv' # 'Results/temperature_sens_Sep17_2025.csv'
 # INTERMEDIATE_OUT = 'Results/temperature_Sep17_2025_no_normalization.csv'
 CLEAN_OUT = 'Results/temperature_Sep17_2025_summary.csv'
 
-BATCH_SIZE = 10 # Must be defined if running a sensitivity run and must be consistent with preprocessing
-TOTAL_SCENARIO_SIZE = 200 # Must be defined if running a sensitivity run and must be consistent with preprocessing # 100000
+BATCH_SIZE = 100 # Must be defined if running a sensitivity run and must be consistent with preprocessing
+TOTAL_SCENARIO_SIZE = 100000 # Must be defined if running a sensitivity run and must be consistent with preprocessing # 100000
 
 if 'lever' in TEMP_OUT or 'Lever' in TEMP_OUT:
     POSTPROCESS_LEVERS = True

--- a/examples/run_cmip6.py
+++ b/examples/run_cmip6.py
@@ -1,5 +1,6 @@
 """Run ICCT emissions scenarios through FaIR and save temperature results."""
 
+import os
 import numpy as np
 import pandas as pd
 import time
@@ -17,29 +18,39 @@ MIN_YEAR = 1940
 MAX_YEAR = 2050
 BASE_SCEN = 'Historical Trends'
 
-# Define output paths. NOTE: "lever", if included in the TEMP_OUT filename, is a special keyword that triggers lever
-# attribution postprocessing (renormalization). If running a lever-based scenario, ensure that "lever" is in the filename
-# and INTERMEDIATE_OUT is additionally defined
-TEMP_OUT = 'Results/temperature_Sep17_2025.csv'
+# Define output paths. NOTE: "lever" and "sense", if included in the TEMP_OUT filename, are a special keywords that
+# triggers lever attribution postprocessing (renormalization) or sensitivity run processing. If running a lever-based
+# scenario, ensure that "lever" is in the filename and INTERMEDIATE_OUT is additionally defined
+TEMP_OUT = 'Results/temperature_sens_Sep17_2025.csv' # 'Results/temperature_lever_Sep17_2025.csv' # 'Results/temperature_sens_Sep17_2025.csv'
 # INTERMEDIATE_OUT = 'Results/temperature_Sep17_2025_no_normalization.csv'
 CLEAN_OUT = 'Results/temperature_Sep17_2025_summary.csv'
+
+BATCH_SIZE = 10 # Must be defined if running a sensitivity run and must be consistent with preprocessing
+TOTAL_SCENARIO_SIZE = 200 # Must be defined if running a sensitivity run and must be consistent with preprocessing # 100000
 
 if 'lever' in TEMP_OUT or 'Lever' in TEMP_OUT:
     POSTPROCESS_LEVERS = True
 else:
     POSTPROCESS_LEVERS = False
+if 'sens' in TEMP_OUT or 'Sens' in TEMP_OUT:
+    RUN_SENSITIVITY = True
+else:
+    RUN_SENSITIVITY = False
 
 print(f"Running a lever attribution scenario (with renormalization): {POSTPROCESS_LEVERS}")
+print(f"Running a sensitivity run: {RUN_SENSITIVITY}")
 
 # Internal input paths
 FORCING_IN = '../inputs/final/rcmip-radiative-forcing-annual-means-v5-1-0.csv'
 EMS_IN = '../inputs/final/rcmip-emissions-annual-means-v5-1-0.csv'
 CONC_IN = '../inputs/final/rcmip-concentrations-annual-means-v5-1-0.csv'
 
-def set_up_fair(scenarios):
+def set_up_fair(scenarios, batch_number=None, batch_size=None):
     """
     Set up the FaIR model with CMIP6-aligned parameters and the specified scenarios, following the example in
-     https://docs.fairmodel.net/en/latest/examples/cmip6_ssp_emissions_run.html
+     https://docs.fairmodel.net/en/latest/examples/cmip6_ssp_emissions_run.html.
+
+    Batch size and number are optional arguments used for sensitivity runs.
     """
     print("Setting up FaIR model...")
 
@@ -86,7 +97,7 @@ def set_up_fair(scenarios):
     df_volcanic = pd.read_csv('../tests/test_data/volcanic_ERF_monthly_175001-201912.csv', index_col='year')
     df_volcanic[1750:].head()
 
-    f.fill_from_rcmip()
+    f.fill_from_rcmip(batch_number, batch_size)
 
     # overwrite volcanic, per example scenario
     volcanic_forcing = np.zeros(351)
@@ -145,7 +156,7 @@ def add_zero_scenarios(df, scenarios):
     return striving_scenarios
 
 
-def clean_temp_output(f, vizcon_scenarios):
+def clean_temp_output(f, vizcon_scenarios=None):
     """
     Takes the output from the FaIR model and averages it across all configurations, filter to surface layer,
     and formats it into a clean dataframe.
@@ -162,32 +173,35 @@ def clean_temp_output(f, vizcon_scenarios):
     # Average across all configs
     df_avg = temp.groupby(["timebounds", "scenario"], as_index=False, dropna=False).agg({"temp": "mean"})
 
-    # Add an 'Avoided' column as the difference from ssp119
-    ssp119 = df_avg[df_avg['scenario'] == 'ssp119'].copy()
-    df_avg = df_avg.merge(ssp119, on='timebounds', suffixes=('', '_ssp119'))
-    df_avg['Avoided'] = df_avg['temp_ssp119'] - df_avg['temp']
+    # Not all sensitivity scenarios will have SSP119 scenario
+    if not RUN_SENSITIVITY:
+        # Add an 'Avoided' column as the difference from ssp119
+        ssp119 = df_avg[df_avg['scenario'] == 'ssp119'].copy()
+        df_avg = df_avg.merge(ssp119, on='timebounds', suffixes=('', '_ssp119'))
+        df_avg['Avoided'] = df_avg['temp_ssp119'] - df_avg['temp']
 
-    # Add a column to indicate SLCP or Kyoto
-    # If scneario name contains 'CO2', 'CH4', or 'N2O', label 'Kyoto; otherwise 'SLCP'
-    # Label 'Pollutant' based on scenario
-    df_avg['Pollutant'] = np.where(df_avg['scenario'].str.contains('CO2'), 'CO2', 'non-CO2')
+        # Add a column to indicate SLCP or Kyoto
+        # If scneario name contains 'CO2', 'CH4', or 'N2O', label 'Kyoto; otherwise 'SLCP'
+        # Label 'Pollutant' based on scenario
+        df_avg['Pollutant'] = np.where(df_avg['scenario'].str.contains('CO2'), 'CO2', 'non-CO2')
 
-    df_avg['Actual Pollutant'] = df_avg['scenario'].str.split('_', expand=True)[1]
+        df_avg['Actual Pollutant'] = df_avg['scenario'].str.split('_', expand=True)[1]
 
-    # Remove the Pollutant values for 'ssp119', 'ssp119_striving', and 'ssp119_zero_tra'
-    df_avg.loc[df_avg['scenario'].isin(['ssp119', 'ssp119_striving', 'ssp119_zero_tra']), 'Pollutant'] = np.nan
-    df_avg.loc[df_avg['scenario'].isin(['ssp119', 'ssp119_striving', 'ssp119_zero_tra']), 'Actual Pollutant'] = np.nan
+        # Remove the Pollutant values for 'ssp119', 'ssp119_striving', and 'ssp119_zero_tra'
+        df_avg.loc[df_avg['scenario'].isin(['ssp119', 'ssp119_striving', 'ssp119_zero_tra']), 'Pollutant'] = np.nan
+        df_avg.loc[df_avg['scenario'].isin(['ssp119', 'ssp119_striving', 'ssp119_zero_tra']), 'Actual Pollutant'] = np.nan
 
-    df_avg = add_zero_scenarios(df_avg, vizcon_scenarios)
 
-    # Add 'Vizcon Scenario' Column
-    for scen in vizcon_scenarios:
-        df_avg.loc[df_avg['scenario'].str.contains(scen), 'Vizcon Scenario'] = scen
+        df_avg = add_zero_scenarios(df_avg, vizcon_scenarios)
 
-    # Rename BAU scenario to Baseline
-    df_avg.loc[df_avg['Vizcon Scenario'] == 'BAU', 'Vizcon Scenario'] = BASE_SCEN
+        # Add 'Vizcon Scenario' Column
+        for scen in vizcon_scenarios:
+            df_avg.loc[df_avg['scenario'].str.contains(scen), 'Vizcon Scenario'] = scen
 
-    df_avg = df_avg.rename(columns={'Striving_temp_attribution': 'Attributable Warming', 'temp': 'Global Temperature Anomaly'})
+        # Rename BAU scenario to Baseline
+        df_avg.loc[df_avg['Vizcon Scenario'] == 'BAU', 'Vizcon Scenario'] = BASE_SCEN
+
+        df_avg = df_avg.rename(columns={'Striving_temp_attribution': 'Attributable Warming', 'temp': 'Global Temperature Anomaly'})
 
     return df_avg
 
@@ -320,57 +334,89 @@ def postprocess_levers(temp):
     return temp
 
 
+def run_fair_with_sensitivity():
+    print(f"Running FaIR in sensitivity mode with batch size {BATCH_SIZE}. Ensure this is consistent with preprocessing.")
+    # Ensure 'Results/sens/{batch_size}' exists
+    if not os.path.exists(f'Results/sens/{BATCH_SIZE}'):
+        os.makedirs(f'Results/sens/{BATCH_SIZE}')
+    # Run in batches
+    for i in range(0, TOTAL_SCENARIO_SIZE, BATCH_SIZE):
+        batch_number = round(i/BATCH_SIZE)
+        # Only read in contrails
+        df_forc = pd.read_csv(f'../inputs/final/batches/{BATCH_SIZE}/rcmip-radiative-forcing-annual-means-v5-1-0_{batch_number}.csv')
+
+        # Get the scenarios for this batch
+        scenarios = list(df_forc['Scenario'].unique())
+
+        # Set up FaIR
+        f = set_up_fair(scenarios, batch_number, BATCH_SIZE)
+
+        # Run the model
+        f.run()
+
+        # Retrieve the temperature results in a clean format
+        temp = clean_temp_output(f, '')
+
+        # Save the results
+        temp.to_csv(f'Results/sens/{BATCH_SIZE}/temperature_{batch_number}.csv', index=False)
+
+
 def main():
     """Set up FaIR, run it, and save results."""
 
     st = time.time()
-    # Read input data
-    forcing = pd.read_csv(FORCING_IN)
-    ems = pd.read_csv(EMS_IN)
-    conc = pd.read_csv(CONC_IN)
 
-    # Define full set of scenarios
-    scenarios = list(set(pd.concat([forcing['Scenario'], ems['Scenario'], conc['Scenario']]).unique()))
+    if RUN_SENSITIVITY:
+        # Run a special setup for sensitivity runs
+        run_fair_with_sensitivity()
+    else:
+        # Read input data
+        forcing = pd.read_csv(FORCING_IN)
+        ems = pd.read_csv(EMS_IN)
+        conc = pd.read_csv(CONC_IN)
 
-    # Replace '_upper' with ' upper' and '_lower' with ' lower' to avoid "_" delimiter issues
-    scenarios = [s.replace('_upper', ' upper').replace('_lower', ' lower') for s in scenarios]
+        # Define full set of scenarios
+        scenarios = list(set(pd.concat([forcing['Scenario'], ems['Scenario'], conc['Scenario']]).unique()))
 
-    vizcon_scenarios =  np.unique([s.split('_')[-1] if '_' in s else s for s in scenarios])
-    # Drop 'ssp119', 'tra', 'zero'
-    vizcon_scenarios = [name for name in vizcon_scenarios if name not in ['ssp119', 'tra']]
-    vizcon_scenarios = list(map(str, vizcon_scenarios))
+        # Replace '_upper' with ' upper' and '_lower' with ' lower' to avoid "_" delimiter issues
+        scenarios = [s.replace('_upper', ' upper').replace('_lower', ' lower') for s in scenarios]
 
-    # Set up FaIR
-    f = set_up_fair(scenarios)
+        vizcon_scenarios =  np.unique([s.split('_')[-1] if '_' in s else s for s in scenarios])
+        # Drop 'ssp119', 'tra', 'zero'
+        vizcon_scenarios = [name for name in vizcon_scenarios if name not in ['ssp119', 'tra']]
+        vizcon_scenarios = list(map(str, vizcon_scenarios))
 
-    # Run the model
-    print("Running FaIR...")
-    f.run()
+        # Set up FaIR
+        f = set_up_fair(scenarios)
 
-    # Retrieve the temperature results in a clean format
-    temp = clean_temp_output(f, vizcon_scenarios)
+        # Run the model
+        print("Running FaIR...")
+        f.run()
 
-    # Rename 'Pollutant' to 'Pollutant Group'
-    temp = temp.rename(columns={'Pollutant': 'Pollutant Group'})
-    temp = temp[['timebounds', 'scenario', 'Vizcon Scenario', 'Pollutant Group',
-                 'Actual Pollutant', 'Attributable Warming', 'Global Temperature Anomaly']]
-    if POSTPROCESS_LEVERS:
-        # Save an intermediate output without lever renormalization
-        temp.to_csv(INTERMEDIATE_OUT, index=False)
-        print(f"Saved intermediate results to {INTERMEDIATE_OUT}")
+        # Retrieve the temperature results in a clean format
+        temp = clean_temp_output(f, vizcon_scenarios)
 
-    temp = postprocess_levers(temp)
+        # Rename 'Pollutant' to 'Pollutant Group'
+        temp = temp.rename(columns={'Pollutant': 'Pollutant Group'})
+        temp = temp[['timebounds', 'scenario', 'Vizcon Scenario', 'Pollutant Group',
+                     'Actual Pollutant', 'Attributable Warming', 'Global Temperature Anomaly']]
+        if POSTPROCESS_LEVERS:
+            # Save an intermediate output without lever renormalization
+            temp.to_csv(INTERMEDIATE_OUT, index=False)
+            print(f"Saved intermediate results to {INTERMEDIATE_OUT}")
 
-    # Save the results
-    temp.to_csv(TEMP_OUT, index=False)
+        temp = postprocess_levers(temp)
 
-    # Save a summary output with just the total attributable warming for each scenario
-    scenario_totals = temp[temp['Actual Pollutant'] == 'All'].copy()
-    scenario_totals = scenario_totals[['timebounds', 'Vizcon Scenario', 'Attributable Warming']]
-    # Pivot 'Vizcon Scenario' to columns
-    scenario_totals = scenario_totals.pivot(index='timebounds', columns='Vizcon Scenario',
-                                            values='Attributable Warming').reset_index()
-    scenario_totals.to_csv(CLEAN_OUT, index=False)
+        # Save the results
+        temp.to_csv(TEMP_OUT, index=False)
+
+        # Save a summary output with just the total attributable warming for each scenario
+        scenario_totals = temp[temp['Actual Pollutant'] == 'All'].copy()
+        scenario_totals = scenario_totals[['timebounds', 'Vizcon Scenario', 'Attributable Warming']]
+        # Pivot 'Vizcon Scenario' to columns
+        scenario_totals = scenario_totals.pivot(index='timebounds', columns='Vizcon Scenario',
+                                                values='Attributable Warming').reset_index()
+        scenario_totals.to_csv(CLEAN_OUT, index=False)
 
     print(f"Ran in {(time.time() - st)/60:.2f} minutes")
 

--- a/examples/run_cmip6.py
+++ b/examples/run_cmip6.py
@@ -21,7 +21,7 @@ BASE_SCEN = 'Historical Trends'
 # Define output paths. NOTE: "lever" and "sens", if included in the TEMP_OUT filename, are a special keywords that
 # triggers lever attribution postprocessing (renormalization) or sensitivity run processing. If running a lever-based
 # scenario, ensure that "lever" is in the filename and INTERMEDIATE_OUT is additionally defined
-TEMP_OUT = 'Results/temperature_sens_Sep17_2025.csv' # 'Results/temperature_lever_Sep17_2025.csv' # 'Results/temperature_sens_Sep17_2025.csv'
+TEMP_OUT = 'Results/temperature_Sep17_2025.csv' # 'Results/temperature_lever_Sep17_2025.csv' # 'Results/temperature_sens_Sep17_2025.csv'
 # INTERMEDIATE_OUT = 'Results/temperature_Sep17_2025_no_normalization.csv'
 CLEAN_OUT = 'Results/temperature_Sep17_2025_summary.csv'
 

--- a/preprocessing/preprocess_pace_ems.py
+++ b/preprocessing/preprocess_pace_ems.py
@@ -14,7 +14,7 @@ EMS_OUT = 'final/PACE_inventory_long.csv' # If SENSITIVITY_FNAME is not None, th
 
 # Optional: If a sensitivity runs file is provided, then only the baseline scenario will be included and
 # all sensitivity runs will be added from the provided file.
-SENSITIVITY_FNAME = 'PACE/pace_baseline_erf_projection_samples.csv'
+SENSITIVITY_FNAME = None #'PACE/pace_baseline_erf_projection_samples.csv'
 
 # Use a separate filename to indicate that the output includes sensitivity runs, which changes the handling in later scripts
 if SENSITIVITY_FNAME is not None:

--- a/preprocessing/preprocess_pace_ems.py
+++ b/preprocessing/preprocess_pace_ems.py
@@ -3,13 +3,24 @@ Convert PACE emissions outputs into inputs for FaIR.
 """
 
 import pandas as pd
+import numpy as np
 
 # set wide display
 pd.set_option('display.width', 1000)
 pd.set_option('display.max_columns', 500)
 
 FNAME_IN = 'PACE/summary_sept16_historical_and_slcp_uq.csv'
-EMS_OUT = 'final/PACE_inventory_long.csv'
+EMS_OUT = 'final/PACE_inventory_long.csv' # If SENSITIVITY_FNAME is not None, this will be replaced to include "_sens"
+
+# Optional: If a sensitivity runs file is provided, then only the baseline scenario will be included and
+# all sensitivity runs will be added from the provided file.
+SENSITIVITY_FNAME = 'PACE/pace_baseline_erf_projection_samples.csv'
+
+# Use a separate filename to indicate that the output includes sensitivity runs, which changes the handling in later scripts
+if SENSITIVITY_FNAME is not None:
+    EMS_OUT = 'final/PACE_inventory_long_sens.csv'
+    BASE_YR_SENS = 2023
+    END_YR_SENS = 2050
 
 CONTRAILS_VAR_NAME = 'ConERF'
 CONTRAILS_UNITS = 'W/m2'
@@ -125,6 +136,37 @@ def convert_units(df_long):
     return df_long
 
 
+def clean_sensitivity_runs(df):
+    """
+    Sensitivity output were provided in the wide format with years as rows and scenarios as columns.
+
+    Though the year rows were not labeled, they covered 2023 to 2050.
+    """
+    assert all(['Sample' in col for col in df.columns])
+
+    # Add a 'Year' column 2023-2050
+    years = np.arange(BASE_YR_SENS, END_YR_SENS+1)
+
+    assert len(years) == df.shape[0]
+
+    df['Year'] = years
+
+    # Melt and add scenario column
+    df = df.melt(id_vars=['Year'], var_name='Scenario', value_name='ems')
+
+    # Add metadata
+    df['Sector'] = 'Aviation'
+    df['Species'] = 'contrails'
+    df['Units'] = 'mW/m2'
+    df['Source'] = 'WTW'
+
+    # Convert units to W/m2
+    df['ems'] = df['ems'] * 1e-3
+    df['Units'] = 'W/m2'
+
+    return df
+
+
 def main():
     """
     Execute the script.
@@ -139,6 +181,16 @@ def main():
     df_long['Species'] = df_long['Species'].str.lower()
     # Remove all '_' from Scenario names since underscores are a key delimiter in later scripts
     df_long['Scenario'] = df_long['Scenario'].str.replace('_', ' ', regex=False)
+
+    if SENSITIVITY_FNAME is not None:
+        # Add the BAU scenario to the mc_simulations
+        bau_contrails = df_long[(df_long['Species'] == 'contrails') & (df_long['Scenario'] == 'BAU')].copy()
+        # Add in contrails from the Monte Carlo simulations
+        sens_simulations = pd.read_csv(SENSITIVITY_FNAME)
+        sens_simulations = clean_sensitivity_runs(sens_simulations)
+
+        # Concatenate the two dataframes
+        df_long = pd.concat([bau_contrails, sens_simulations], ignore_index=True)
 
     df_long.to_csv(EMS_OUT, index=False)
 

--- a/src/fair/io/fill_from.py
+++ b/src/fair/io/fill_from.py
@@ -226,7 +226,7 @@ def fill_from_csv(
 
 
 # TO DO: make part of fill_from_csv
-def fill_from_rcmip(self):
+def fill_from_rcmip(self, batch_number=None, batch_size=None):
     """Fill emissions, concentrations and/or forcing from RCMIP scenarios.
 
     This method is part of the `FAIR` class. It uses self.scenarios to look up
@@ -282,9 +282,18 @@ def fill_from_rcmip(self):
     # )
 
     # Modified code to read local copies
-    df_emis = pd.read_csv('../inputs/final/rcmip-emissions-annual-means-v5-1-0.csv')
-    df_conc = pd.read_csv('../inputs/final/rcmip-concentrations-annual-means-v5-1-0.csv')
-    df_forc = pd.read_csv('../inputs/final/rcmip-radiative-forcing-annual-means-v5-1-0.csv')
+    if batch_number is not None and batch_size is not None:
+        df_emis = pd.read_csv(
+            f'../inputs/final/batches/{batch_size}/rcmip-emissions-annual-means-v5-1-0_{batch_number}.csv'
+        )
+        df_conc = pd.read_csv(
+            f'../inputs/final/batches/{batch_size}/rcmip-concentrations-annual-means-v5-1-0_{batch_number}.csv')
+        df_forc = pd.read_csv(
+            f'../inputs/final/batches/{batch_size}/rcmip-radiative-forcing-annual-means-v5-1-0_{batch_number}.csv')
+    else:
+        df_emis = pd.read_csv('../inputs/final/rcmip-emissions-annual-means-v5-1-0.csv')
+        df_conc = pd.read_csv('../inputs/final/rcmip-concentrations-annual-means-v5-1-0.csv')
+        df_forc = pd.read_csv('../inputs/final/rcmip-radiative-forcing-annual-means-v5-1-0.csv')
 
     # filter to scenarios
     df_emis = df_emis[df_emis["Scenario"].isin(self.scenarios)]


### PR DESCRIPTION
Adds handling to the 3 existing scripts to run contrail sensitivity analysis and one aggregation script.

## `preprocess_pace_ems.py`

If running a sensitivity analysis (SENSITIVITY_FNAME equals a something other than None), then the sensitivity file is read in and cleaned separately from how a PACE output would be preprocessed. The intermediate file is saved as `final/PACE_inventory_long_sens.csv`.

## `create_custom_scenario.py`

If running a sensitivity setup (controlled by if EMS_IN == `preprocessing/final/PACE_inventory_long_sens.csv`), then scenarios are batched using the bin size and saved as separate files. Only contrails are perturbed in the CMIP6 default input.

## `run_cmip6.py`

In addition to the already existing "lever" keyword in `TEMP_OUT`, I've added a "sens" keyword. If "sens" is included, scenarios are run in batches using the batched output files created in `create_custom_scenario.py`.

## New aggregation script

I added `examples/Results/sens/combine_sens.py` to combine the results from the sensitivity analysis scenarios into a combined file and an average/95th percentile file. Here's an example of the export of all of the runs (only including 200 samples):

<img width="1534" height="665" alt="Screenshot 2025-11-25 at 2 20 41 PM" src="https://github.com/user-attachments/assets/472738ca-fedc-43dc-ac42-98e5435829f3" />
